### PR TITLE
fix: Register Bicep reviewer in BUNDLED_SKILLS list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Release tagging:** After merging a release PR, create a git tag matching the version (e.g., `git tag v1.2.6 && git push origin v1.2.6`).
 
+## [2.0.9] - 2026-01-27
+
+### Fixed
+
+- Bicep reviewer skill not included in `ralph sync` output
+  - Added `reviewers/language/bicep` to `BUNDLED_SKILLS` list in skills service
+
 ## [2.0.8] - 2026-01-27
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ralph-cli"
-version = "2.0.8"
+version = "2.0.9"
 description = "A Python CLI tool that implements the Ralph autonomous iteration pattern for Claude Code"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/ralph/__init__.py
+++ b/src/ralph/__init__.py
@@ -1,3 +1,3 @@
 """Ralph CLI - Autonomous iteration pattern for Claude Code."""
 
-__version__ = "2.0.8"
+__version__ = "2.0.9"

--- a/src/ralph/services/skills.py
+++ b/src/ralph/services/skills.py
@@ -26,6 +26,7 @@ BUNDLED_SKILLS = [
     "ralph/tasks",
     "reviewers/code-simplifier",
     "reviewers/github-actions",
+    "reviewers/language/bicep",
     "reviewers/language/python",
     "reviewers/release",
     "reviewers/repo-structure",

--- a/uv.lock
+++ b/uv.lock
@@ -402,7 +402,7 @@ wheels = [
 
 [[package]]
 name = "ralph-cli"
-version = "2.0.8"
+version = "2.0.9"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- Fixes `ralph sync` not including the bicep-reviewer skill
- The skill was added in v2.0.8 but not registered in `BUNDLED_SKILLS` list
- Bumps version to 2.0.9

## Test plan

- [x] All quality checks pass (pyright, ruff, pytest)
- [ ] Verify `ralph sync` now shows 10 skills including bicep-reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)