### PR TITLE
fix: use UTF-8 encoding for subprocess streams (Windows UnicodeDecodeError)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Release tagging:** After merging a release PR, create a git tag matching the version (e.g., `git tag v1.2.6 && git push origin v1.2.6`).
 
+## [2.2.1] - 2026-03-19
+
+### Fixed
+
+- `UnicodeDecodeError` on Windows when non-ASCII characters appear in subprocess output (#67)
+  - Explicitly set `encoding='utf-8'` and `errors='replace'` on all subprocess calls in `ClaudeService`
+
 ## [2.2.0] - 2026-02-08
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ralph-cli"
-version = "2.2.0"
+version = "2.2.1"
 description = "A Python CLI tool that implements the Ralph autonomous iteration pattern for Claude Code"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/ralph/__init__.py
+++ b/src/ralph/__init__.py
@@ -1,3 +1,3 @@
 """Ralph CLI - Autonomous iteration pattern for Claude Code."""
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"

--- a/src/ralph/services/claude.py
+++ b/src/ralph/services/claude.py
@@ -193,6 +193,8 @@ without asking for confirmation or permission."""
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
             )
 
             if stream:
@@ -249,6 +251,8 @@ without asking for confirmation or permission."""
                 args,
                 cwd=self.working_dir,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
             )
             return result.returncode
         except FileNotFoundError as e:


### PR DESCRIPTION
Closes #67

Explicitly set `encoding='utf-8'` and `errors='replace'` on all subprocess calls in `ClaudeService` to prevent `UnicodeDecodeError` on Windows when non-ASCII characters appear in process output.

Generated with [Claude Code](https://claude.ai/code)