### PR TITLE
chore: remove obsolete Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "local>jackemcpherson/renovate-config"
-  ]
-}


### PR DESCRIPTION
Renovate policy and execution now live in the central [github-infra control plane](https://github.com/jackemcpherson/github-infra/issues/25). The central runner has completed a successful 21-repository fleet proof with repository configuration ignored, and any repository-specific policy is represented in the canonical catalog.\n\nRemove this obsolete leaf configuration so the visible source of truth matches runtime behavior.